### PR TITLE
DrawTilesParticleRenderer fix for bug that displays last frame of empty particle system.

### DIFF
--- a/org/zamedev/particles/renderers/DrawTilesParticleRenderer.hx
+++ b/org/zamedev/particles/renderers/DrawTilesParticleRenderer.hx
@@ -67,6 +67,7 @@ class DrawTilesParticleRenderer extends Sprite implements ParticleSystemRenderer
 
         if (dataList.length == 0) {
             removeEventListener(Event.ENTER_FRAME, onEnterFrame);
+			graphics.clear();
         }
 
         return this;


### PR DESCRIPTION
When the last particle system is removed make sure we clear the graphics
object.
