### PR TITLE
Depricated @:enum abstract is replaced by enum abstract

### DIFF
--- a/org/zamedev/particles/internal/tiff/Compression.hx
+++ b/org/zamedev/particles/internal/tiff/Compression.hx
@@ -1,7 +1,6 @@
 package org.zamedev.particles.internal.tiff;
 
-@:enum
-abstract Compression(Int) {
+enum abstract Compression(Int) {
     var Uncompressed = 1;
     var CCITT_1D = 2;
     var Group_3_Fax = 3;

--- a/org/zamedev/particles/internal/tiff/DataType.hx
+++ b/org/zamedev/particles/internal/tiff/DataType.hx
@@ -1,7 +1,6 @@
 package org.zamedev.particles.internal.tiff;
 
-@:enum
-abstract DataType(Int) {
+enum abstract DataType(Int) {
     var BYTE = 1; // 8-bit unsigned integer
 
     // The value of the Count part of an ASCII field entry includes the NUL. If padding

--- a/org/zamedev/particles/internal/tiff/ExtraSamples.hx
+++ b/org/zamedev/particles/internal/tiff/ExtraSamples.hx
@@ -1,7 +1,6 @@
 package org.zamedev.particles.internal.tiff;
 
-@:enum
-abstract ExtraSamples(Int) {
+enum abstract ExtraSamples(Int) {
     var Unspecified = 0;
     var AssociatedAlpha = 1;
     var UnassociatedAlpha = 2;

--- a/org/zamedev/particles/internal/tiff/PhotometricInterpretation.hx
+++ b/org/zamedev/particles/internal/tiff/PhotometricInterpretation.hx
@@ -1,7 +1,6 @@
 package org.zamedev.particles.internal.tiff;
 
-@:enum
-abstract PhotometricInterpretation(Int) {
+enum abstract PhotometricInterpretation(Int) {
     var WhiteIsZero = 0;
     var BlackIsZero = 1;
     var RGB = 2;

--- a/org/zamedev/particles/internal/tiff/PlanarConfiguration.hx
+++ b/org/zamedev/particles/internal/tiff/PlanarConfiguration.hx
@@ -1,7 +1,6 @@
 package org.zamedev.particles.internal.tiff;
 
-@:enum
-abstract PlanarConfiguration(Int) {
+enum abstract PlanarConfiguration(Int) {
     var Chunky = 1;
     var Planar = 2;
 }

--- a/org/zamedev/particles/internal/tiff/SampleFormat.hx
+++ b/org/zamedev/particles/internal/tiff/SampleFormat.hx
@@ -1,7 +1,6 @@
 package org.zamedev.particles.internal.tiff;
 
-@:enum
-abstract SampleFormat(Int) {
+enum abstract SampleFormat(Int) {
     var Unsigned = 1; // unsigned integer data
     var Signed = 2; // two's complement signed integer data
     var IEEE = 3; // IEEE floating point data

--- a/org/zamedev/particles/internal/tiff/TagId.hx
+++ b/org/zamedev/particles/internal/tiff/TagId.hx
@@ -1,7 +1,6 @@
 package org.zamedev.particles.internal.tiff;
 
-@:enum
-abstract TagId(Int) {
+enum abstract TagId(Int) {
     // hex representation, type, number of values
     var NewSubFileType = 254; // 0x00fe, LONG, 1
     var SubFileType = 255; // 0x00ff, SHORT, 1


### PR DESCRIPTION
Just a quick fix to avoid warnings...